### PR TITLE
Fix Chrome api when auto attaching messages

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -34,11 +34,15 @@ export class FinchApi {
     this.onMessage = this.onMessage.bind(this);
     this.onExternalMessage = this.onExternalMessage.bind(this);
 
+    const attachOptions = {
+      messageKey: this.messageKey ?? FinchMessageKey.Generic,
+    };
+
     if (attachMessages) {
-      addMessageListener(this.onMessage);
+      addMessageListener(this.onMessage, attachOptions);
     }
     if (attachExternalMessages) {
-      addExteneralMessageListener(this.onExternalMessage);
+      addExteneralMessageListener(this.onExternalMessage, attachOptions);
     }
   }
 

--- a/src/browser.test.ts
+++ b/src/browser.test.ts
@@ -1,0 +1,81 @@
+import { addMessageListener, addExteneralMessageListener } from "./browser";
+
+describe("addMessageListener", () => {
+  it("should if using the chrome api immediatly return true and call sendResponse", () => {
+    expect.assertions(3);
+    const sendResponseMock = jest.fn();
+    const handler = jest.fn().mockImplementation(() => {
+      // NOTE: fake promise to avoid async
+      return {
+        then: (send) => {
+          send({ foo: "bar" });
+        },
+      };
+    });
+
+    globalThis.chrome = {
+      runtime: {
+        // @ts-ignore
+        onMessage: {
+          addListener: jest.fn().mockImplementation((methodToTest) => {
+            //
+            const resp = methodToTest(
+              {
+                type: "foo",
+                query: "",
+                variables: {},
+              },
+              {},
+              sendResponseMock
+            );
+            expect(resp).toBe(true);
+            expect(handler).toBeCalled();
+            expect(sendResponseMock).toBeCalledWith({ foo: "bar" });
+          }),
+        },
+      },
+    };
+
+    addMessageListener(handler, { messageKey: "foo" });
+  });
+});
+
+describe("addExteneralMessageListener", () => {
+  it("should if using the chrome api immediatly return true and call sendResponse", () => {
+    expect.assertions(3);
+    const sendResponseMock = jest.fn();
+    const handler = jest.fn().mockImplementation(() => {
+      // NOTE: fake promise to avoid async
+      return {
+        then: (send) => {
+          send({ foo: "bar" });
+        },
+      };
+    });
+
+    globalThis.chrome = {
+      runtime: {
+        // @ts-ignore
+        onMessageExternal: {
+          addListener: jest.fn().mockImplementation((methodToTest) => {
+            //
+            const resp = methodToTest(
+              {
+                type: "foo",
+                query: "",
+                variables: {},
+              },
+              {},
+              sendResponseMock
+            );
+            expect(resp).toBe(true);
+            expect(handler).toBeCalled();
+            expect(sendResponseMock).toBeCalledWith({ foo: "bar" });
+          }),
+        },
+      },
+    };
+
+    addExteneralMessageListener(handler, { messageKey: "foo" });
+  });
+});

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,13 +1,30 @@
 import { FinchMessage } from "./types";
 
+/* 
+  NOTE: chrome apis need to return true the call sendResponse
+  https://developer.chrome.com/docs/extensions/mv2/messaging/#simple
+*/
+
 export const addMessageListener = (
   handler: (
     message: FinchMessage,
     sender: browser.runtime.MessageSender | chrome.runtime.MessageSender
-  ) => Promise<unknown>
+  ) => Promise<unknown>,
+  options: { messageKey: string }
 ) => {
   if (typeof chrome === "object") {
-    chrome.runtime.onMessage.addListener(handler);
+    chrome.runtime.onMessage.addListener(
+      (
+        message: { type?: string; [key: string]: any },
+        sender: chrome.runtime.MessageSender,
+        sendReponse: (payload: any) => void
+      ) => {
+        if (message.type === options.messageKey) {
+          handler(message, sender).then((response) => sendReponse(response));
+          return true;
+        }
+      }
+    );
   } else if (typeof browser === "object") {
     browser.runtime.onMessage.addListener(handler);
   }
@@ -17,10 +34,22 @@ export const addExteneralMessageListener = (
   handler: (
     message: FinchMessage,
     sender: browser.runtime.MessageSender | chrome.runtime.MessageSender
-  ) => Promise<unknown>
+  ) => Promise<unknown>,
+  options: { messageKey: string }
 ) => {
   if (typeof chrome === "object") {
-    chrome.runtime.onMessageExternal.addListener(handler);
+    chrome.runtime.onMessageExternal.addListener(
+      (
+        message: { type?: string; [key: string]: any },
+        sender: chrome.runtime.MessageSender,
+        sendReponse: (payload: any) => void
+      ) => {
+        if (message.type === options.messageKey) {
+          handler(message, sender).then((response) => sendReponse(response));
+          return true;
+        }
+      }
+    );
   } else if (typeof browser === "object") {
     browser.runtime.onMessageExternal.addListener(handler);
   }


### PR DESCRIPTION
## Description

When auto attaching the internal polyfill failed to respond when using the `chrome` api's. This is due to a behavior that the chrome api's have when dealing with async messages. 

See notes [here](https://developer.chrome.com/docs/extensions/mv2/messaging/#simple)

Also I added in some test for these use cases. 
