### PR TITLE
External messaging using document events.

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@graphql-tools/schema": "^7.1.2",
     "graphql-middleware": "^6.0.4",
     "graphql-tag": "^2.11.0",
-    "use-deep-compare-effect": "^1.6.1"
+    "use-deep-compare-effect": "^1.6.1",
+    "uuid": "^8.3.2"
   }
 }

--- a/src/background/FinchApi.ts
+++ b/src/background/FinchApi.ts
@@ -149,7 +149,9 @@ export class FinchApi {
     if (message.type === messageKey && message.query) {
       const { variables, query } = message;
       return this.query(query, variables ?? {}, {
-        source: FinchMessageSource.Message,
+        source: message.external
+          ? FinchMessageSource.ExternalMessage
+          : FinchMessageSource.Message,
         sender,
       });
     }

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,10 +1,12 @@
 import { FinchMessage } from './types';
 
-/* 
-  NOTE: chrome apis need to return true the call sendResponse
-  https://developer.chrome.com/docs/extensions/mv2/messaging/#simple
-*/
-
+/**
+ * addMessageListener adds a message event handler
+ * chrome apis need to return true the call sendResponse
+ * https://developer.chrome.com/docs/extensions/mv2/messaging/#simple
+ * @param handler the event handler
+ * @param options some options to configure the message passing
+ */
 export const addMessageListener = (
   handler: (
     message: FinchMessage,
@@ -30,6 +32,12 @@ export const addMessageListener = (
   }
 };
 
+/**
+ * addExternalMessageListener adds an external message event handler
+ * chrome apis need to return true the call sendResponse
+ * @param handler the event handler
+ * @param options some options to configure the message passing
+ */
 export const addExternalMessageListener = (
   handler: (
     message: FinchMessage,
@@ -55,6 +63,10 @@ export const addExternalMessageListener = (
   }
 };
 
+/**
+ * sendMessage to the background process supports both external and
+ * internal messaging
+ */
 export async function sendMessage<MessageResponse extends {}>(
   message: unknown,
 ): Promise<MessageResponse>;
@@ -92,3 +104,14 @@ export async function sendMessage<MessageResponse extends {}>(
     ),
   );
 }
+
+/**
+ * getExtensionId is a method to get the current extension id.
+ * @returns string
+ */
+export const getExtensionId = () => {
+  if (typeof chrome !== 'undefined') {
+    return chrome.runtime.id;
+  }
+  return browser.runtime.id;
+};

--- a/src/client.ts
+++ b/src/client.ts
@@ -16,11 +16,13 @@ const messageCreator = <Variables extends GenericVariables = {}>(
   query: string | DocumentNode,
   variables: Variables,
   messageKey?: string,
+  external?: boolean,
 ) => {
   return {
     type: messageKey ?? FinchMessageKey.Generic,
     query: isDocumentNode(query) ? query : gql(query),
     variables,
+    external,
   };
 };
 
@@ -33,6 +35,7 @@ const messageCreator = <Variables extends GenericVariables = {}>(
  * @param options set of options for configuring this query.
  * @param options.messageKey a custom message key to send to the extension
  * @param options.id an id of the extension to send the query to.
+ * @param options.external if the call is coming from an external location
  * @returns a promise that resolves a graphQL response.
  */
 export const queryApi = async <
@@ -45,7 +48,7 @@ export const queryApi = async <
 ) => {
   const { id: extensionId, messageKey } = options;
   const args: [string, unknown] | [unknown] = [
-    messageCreator<Variables>(query, variables, messageKey),
+    messageCreator<Variables>(query, variables, messageKey, options.external),
   ];
 
   if (extensionId) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -54,7 +54,9 @@ export const queryApi = async <
   if (extensionId) {
     args.unshift(extensionId);
     if (isListeningOnDocument()) {
-      return queryApiFromDocument<Query, Variables>(query, variables);
+      return queryApiFromDocument<Query, Variables>(query, variables, {
+        extensionId,
+      });
     }
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,9 +1,17 @@
 import { DocumentNode, GraphQLFormattedError } from 'graphql';
 import gql from 'graphql-tag';
 import { sendMessage } from './browser';
+import { isListeningOnDocument, queryApiFromDocument } from './external';
 import { GenericVariables, FinchMessageKey, FinchQueryOptions } from './types';
 import { isDocumentNode } from './utils';
 
+/**
+ * messageCreator is a function that create a finch message to send to the background process
+ * @param query the graphQL query to send to api
+ * @param variables the variables for the graphQL query.
+ * @param messageKey optional message key that will get sent to background script
+ * @returns the custom message object for this query
+ */
 const messageCreator = <Variables extends GenericVariables = {}>(
   query: string | DocumentNode,
   variables: Variables,
@@ -16,6 +24,17 @@ const messageCreator = <Variables extends GenericVariables = {}>(
   };
 };
 
+/**
+ * queryApi is a methods that adds a sugary syntax on-top of browser.messaging
+ * for Finch GraphQL. This makes it so you can call this method without having to
+ * worry about how the message is getting sent.
+ * @param query a string or graphQL Document Node query
+ * @param variables the variables for the graphQL query.
+ * @param options set of options for configuring this query.
+ * @param options.messageKey a custom message key to send to the extension
+ * @param options.id an id of the extension to send the query to.
+ * @returns a promise that resolves a graphQL response.
+ */
 export const queryApi = async <
   Query extends {} = {},
   Variables extends GenericVariables = {}
@@ -31,11 +50,13 @@ export const queryApi = async <
 
   if (extensionId) {
     args.unshift(extensionId);
+    if (isListeningOnDocument()) {
+      return queryApiFromDocument<Query, Variables>(query, variables);
+    }
   }
 
-  const resp = sendMessage<{
+  return sendMessage<{
     data: Query | null;
     errors?: GraphQLFormattedError[];
   }>(...args);
-  return resp;
 };

--- a/src/external/createEvents.ts
+++ b/src/external/createEvents.ts
@@ -13,13 +13,14 @@ import {
  * @returns A CustomEvent with the graphQL query added to it, and a requestId
  */
 export const createRequestEvent = (
+  extensionId: string,
   query: DocumentNode | string,
   variables?: any,
 ) => {
   return new CustomEvent<FinchRequestEventProps>(
     FinchDocumentEventNames.Request,
     {
-      detail: { query, variables, requestId: v4() },
+      detail: { query, variables, requestId: v4(), extensionId },
     },
   );
 };

--- a/src/external/createEvents.ts
+++ b/src/external/createEvents.ts
@@ -1,0 +1,45 @@
+import { DocumentNode, GraphQLFormattedError } from 'graphql';
+import { v4 } from 'uuid';
+import {
+  FinchRequestEventProps,
+  FinchDocumentEventNames,
+  FinchResponseEventProps,
+} from './types';
+
+/**
+ * createRequestEvent creates a event that will be consumed by the extension
+ * @param query A graphql Document Node
+ * @param variables If the query or mutation needs variables they can be passed here
+ * @returns A CustomEvent with the graphQL query added to it, and a requestId
+ */
+export const createRequestEvent = (
+  query: DocumentNode | string,
+  variables?: any,
+) => {
+  return new CustomEvent<FinchRequestEventProps>(
+    FinchDocumentEventNames.Request,
+    {
+      detail: { query, variables, requestId: v4() },
+    },
+  );
+};
+
+/**
+ * createResponseEvent creates an event that is the response to the request event.
+ * @param requestId A unique identifier that comes from the initial request event.
+ * @param data The response data from graphQL
+ * @param errors An array of graphQL errors if there was any
+ * @returns The custom event with all the data added to it.
+ */
+export const createResponseEvent = (
+  requestId: string,
+  data: any,
+  errors?: Array<GraphQLFormattedError>,
+) => {
+  return new CustomEvent<FinchResponseEventProps>(
+    FinchDocumentEventNames.Response,
+    {
+      detail: { data, errors, requestId },
+    },
+  );
+};

--- a/src/external/external.test.ts
+++ b/src/external/external.test.ts
@@ -1,0 +1,115 @@
+import gql from 'graphql-tag';
+import { FinchMessageKey } from '../types';
+import { isListeningOnDocument } from './isListeningOnDocument';
+import { listenForDocumentQueries } from './listenForDocumentQueries';
+import { queryApiFromDocument } from './queryApiFromDocument';
+describe('external document messaging', () => {
+  let unbindListener: () => void;
+  let ogChrome = window.chrome;
+  beforeAll(() => {
+    window.chrome = undefined;
+  });
+  afterAll(() => {
+    window.chrome = ogChrome;
+  });
+  afterEach(() => {
+    if (unbindListener) {
+      unbindListener();
+    }
+  });
+  it('should fail to send if there is no listeners attached', async () => {
+    await expect(
+      queryApiFromDocument(`query test { foo }`, {}),
+    ).rejects.toMatchObject({
+      message: 'Finch is not currently listening for messages',
+    });
+  });
+  it('it should send a message to the browser message if there is a listener', async () => {
+    const query = gql`
+      query test {
+        foo
+      }
+    `;
+    const variables = {};
+
+    browser.runtime.sendMessage = jest.fn().mockResolvedValue({ data: null });
+    unbindListener = listenForDocumentQueries();
+    expect(isListeningOnDocument()).toBe(true);
+
+    const resp = await queryApiFromDocument(query, variables);
+
+    expect(browser.runtime.sendMessage).toBeCalledWith({
+      query: query,
+      variables: variables,
+      type: FinchMessageKey.Generic,
+    });
+    expect(resp).toEqual({ data: null });
+  });
+
+  it('it should timeout if the request does not respond', async () => {
+    const query = gql`
+      query test {
+        foo
+      }
+    `;
+    const variables = {};
+
+    browser.runtime.sendMessage = jest.fn().mockImplementation(() => {
+      return new Promise(resolve => {
+        setTimeout(() => {
+          resolve({ data: null });
+        }, 300);
+      });
+    });
+    unbindListener = listenForDocumentQueries();
+    expect(isListeningOnDocument()).toBe(true);
+
+    await expect(
+      queryApiFromDocument(query, variables, { timeout: 100 }),
+    ).rejects.toMatchObject({
+      message: 'Finch request has timed out.',
+    });
+  });
+  it('it should only respond with the correct response', async () => {
+    const query = `
+      query foo {
+        foo
+      }
+    `;
+    const variables = {};
+
+    browser.runtime.sendMessage = jest.fn().mockImplementation(message => {
+      // TODO: this should be an abstraction in FinchAPI that we can reuse.
+      let operationName = undefined;
+      const operationDef = message.query.definitions.find(
+        def => def.kind === 'OperationDefinition',
+      );
+      if (operationDef && 'name' in operationDef) {
+        operationName = operationDef?.name?.value ?? undefined;
+      }
+      // Wait for 500 ms
+      if (operationName === 'foo') {
+        return new Promise(resolve => {
+          setTimeout(() => {
+            resolve({ data: { foo: 'bar' } });
+          }, 500);
+        });
+      }
+      return Promise.resolve({ data: null });
+    });
+    unbindListener = listenForDocumentQueries();
+    expect(isListeningOnDocument()).toBe(true);
+
+    const responses = await Promise.all([
+      queryApiFromDocument(query, variables),
+      queryApiFromDocument(`query bar { foo }`, variables),
+      queryApiFromDocument(query, variables),
+    ]);
+
+    expect(responses).toEqual([
+      { data: { foo: 'bar' } },
+      { data: null },
+      { data: { foo: 'bar' } },
+    ]);
+  });
+});

--- a/src/external/external.test.ts
+++ b/src/external/external.test.ts
@@ -45,6 +45,7 @@ describe('external document messaging', () => {
       query: query,
       variables: variables,
       type: FinchMessageKey.Generic,
+      external: true,
     });
     expect(resp).toEqual({ data: null });
   });

--- a/src/external/external.test.ts
+++ b/src/external/external.test.ts
@@ -24,7 +24,7 @@ describe('external document messaging', () => {
       message: 'Finch is not currently listening for messages',
     });
   });
-  it('it should send a message to the browser message if there is a listener', async () => {
+  it('should send a message to the browser message if there is a listener', async () => {
     const query = gql`
       query test {
         foo
@@ -46,7 +46,7 @@ describe('external document messaging', () => {
     expect(resp).toEqual({ data: null });
   });
 
-  it('it should timeout if the request does not respond', async () => {
+  it('should timeout if the request does not respond', async () => {
     const query = gql`
       query test {
         foo
@@ -70,7 +70,7 @@ describe('external document messaging', () => {
       message: 'Finch request has timed out.',
     });
   });
-  it('it should only respond with the correct response', async () => {
+  it('should only respond with the correct response', async () => {
     const query = `
       query foo {
         foo

--- a/src/external/external.test.ts
+++ b/src/external/external.test.ts
@@ -8,6 +8,7 @@ describe('external document messaging', () => {
   let ogChrome = window.chrome;
   beforeAll(() => {
     window.chrome = undefined;
+    Object.assign(browser.runtime, { id: 'foo' });
   });
   afterAll(() => {
     window.chrome = ogChrome;
@@ -19,7 +20,7 @@ describe('external document messaging', () => {
   });
   it('should fail to send if there is no listeners attached', async () => {
     await expect(
-      queryApiFromDocument(`query test { foo }`, {}),
+      queryApiFromDocument(`query test { foo }`, {}, { extensionId: 'foo' }),
     ).rejects.toMatchObject({
       message: 'Finch is not currently listening for messages',
     });
@@ -36,7 +37,9 @@ describe('external document messaging', () => {
     unbindListener = listenForDocumentQueries();
     expect(isListeningOnDocument()).toBe(true);
 
-    const resp = await queryApiFromDocument(query, variables);
+    const resp = await queryApiFromDocument(query, variables, {
+      extensionId: 'foo',
+    });
 
     expect(browser.runtime.sendMessage).toBeCalledWith({
       query: query,
@@ -65,7 +68,10 @@ describe('external document messaging', () => {
     expect(isListeningOnDocument()).toBe(true);
 
     await expect(
-      queryApiFromDocument(query, variables, { timeout: 100 }),
+      queryApiFromDocument(query, variables, {
+        timeout: 100,
+        extensionId: 'foo',
+      }),
     ).rejects.toMatchObject({
       message: 'Finch request has timed out.',
     });
@@ -101,9 +107,11 @@ describe('external document messaging', () => {
     expect(isListeningOnDocument()).toBe(true);
 
     const responses = await Promise.all([
-      queryApiFromDocument(query, variables),
-      queryApiFromDocument(`query bar { foo }`, variables),
-      queryApiFromDocument(query, variables),
+      queryApiFromDocument(query, variables, { extensionId: 'foo' }),
+      queryApiFromDocument(`query bar { foo }`, variables, {
+        extensionId: 'foo',
+      }),
+      queryApiFromDocument(query, variables, { extensionId: 'foo' }),
     ]);
 
     expect(responses).toEqual([

--- a/src/external/index.ts
+++ b/src/external/index.ts
@@ -1,0 +1,3 @@
+export { listenForDocumentQueries } from './listenForDocumentQueries';
+export { queryApiFromDocument } from './queryApiFromDocument';
+export { isListeningOnDocument } from './isListeningOnDocument';

--- a/src/external/isListeningOnDocument.ts
+++ b/src/external/isListeningOnDocument.ts
@@ -1,0 +1,7 @@
+/**
+ * isListeningOnDocument is a small utility to query the API using document events.
+ * @returns A boolean value if Finch is listening on the document.
+ */
+export const isListeningOnDocument = () => {
+  return !!document.body.hasAttribute('data-finch-listener');
+};

--- a/src/external/listenForDocumentQueries.ts
+++ b/src/external/listenForDocumentQueries.ts
@@ -1,0 +1,37 @@
+import { queryApi } from '../client';
+import { FinchQueryOptions } from '../types';
+import { createResponseEvent } from './createEvents';
+import { FinchRequestEvent, FinchDocumentEventNames } from './types';
+
+/**
+ * listenForDocumentQueries binds to document events so websites can
+ * send Finch GraphQL queries and mutations from document events. This
+ * depends if you are able to inject into those pages as well.
+ *
+ * This method will also attach a **data-finch-listener** attribute on
+ * the body element to be able to known the event bound.
+ *
+ * @param options the finch query options that are passed to queryApi method
+ * @returns A function that stops listening to the events
+ */
+export const listenForDocumentQueries = (options?: FinchQueryOptions) => {
+  const onMessage = async (event: FinchRequestEvent) => {
+    const resp = await queryApi(
+      event.detail.query,
+      event.detail.variables,
+      options,
+    );
+    const responseEvent = createResponseEvent(
+      event.detail.requestId,
+      resp.data,
+      resp.errors,
+    );
+    document.dispatchEvent(responseEvent);
+  };
+  document.addEventListener(FinchDocumentEventNames.Request, onMessage);
+  document.body.setAttribute('data-finch-listener', `${Date.now()}`);
+  return () => {
+    document.removeEventListener(FinchDocumentEventNames.Request, onMessage);
+    document.body.removeAttribute('data-finch-listener');
+  };
+};

--- a/src/external/listenForDocumentQueries.ts
+++ b/src/external/listenForDocumentQueries.ts
@@ -16,11 +16,10 @@ import { FinchRequestEvent, FinchDocumentEventNames } from './types';
  */
 export const listenForDocumentQueries = (options?: FinchQueryOptions) => {
   const onMessage = async (event: FinchRequestEvent) => {
-    const resp = await queryApi(
-      event.detail.query,
-      event.detail.variables,
-      options,
-    );
+    const resp = await queryApi(event.detail.query, event.detail.variables, {
+      ...options,
+      external: true,
+    });
     const responseEvent = createResponseEvent(
       event.detail.requestId,
       resp.data,

--- a/src/external/queryApiFromDocument.ts
+++ b/src/external/queryApiFromDocument.ts
@@ -1,0 +1,59 @@
+import { DocumentNode, GraphQLFormattedError } from 'graphql';
+import { createRequestEvent } from './createEvents';
+import { isListeningOnDocument } from './isListeningOnDocument';
+import { FinchDocumentEventNames, FinchResponseEvent } from './types';
+
+const DEFAULT_TIMEOUT = 3000;
+
+interface QueryApiFromDocumentOptions {
+  timeout?: number;
+}
+
+/**
+ * queryApiFromDocument sends a graphQL query through the document and waits
+ * for a response to the event.
+ *
+ * @param query a graphQL document node
+ * @param variables the variables to be passed to the query
+ * @param options some options to help configure the request
+ * @param options.timeout the amount of time in milliseconds to wait for response
+ * @returns A promise that resolves to the response of the query
+ */
+export const queryApiFromDocument = async <
+  Query extends {},
+  Variables extends any
+>(
+  query: DocumentNode | string,
+  variables?: Variables,
+  options?: QueryApiFromDocumentOptions,
+): Promise<{ data: Query | null; errors: Array<GraphQLFormattedError> }> => {
+  if (!isListeningOnDocument()) {
+    return Promise.reject(
+      new Error('Finch is not currently listening for messages'),
+    );
+  }
+  const requestEvent = createRequestEvent(query, variables);
+  const requestId = requestEvent.detail.requestId;
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error('Finch request has timed out.'));
+      document.removeEventListener(FinchDocumentEventNames.Response, onMessage);
+    }, options?.timeout ?? DEFAULT_TIMEOUT);
+    const onMessage = async (event: FinchResponseEvent) => {
+      // Filter out other events that might be coming into the handler
+      if (event.detail.requestId !== requestId) {
+        return;
+      }
+      clearTimeout(timer);
+      resolve({
+        data: event.detail.data as Query | null,
+        errors: event.detail.errors,
+      });
+      // Unbind after we got a response
+      document.removeEventListener(FinchDocumentEventNames.Response, onMessage);
+    };
+    document.addEventListener(FinchDocumentEventNames.Response, onMessage);
+    document.dispatchEvent(requestEvent);
+  });
+};

--- a/src/external/queryApiFromDocument.ts
+++ b/src/external/queryApiFromDocument.ts
@@ -7,6 +7,7 @@ const DEFAULT_TIMEOUT = 3000;
 
 interface QueryApiFromDocumentOptions {
   timeout?: number;
+  extensionId: string;
 }
 
 /**
@@ -32,7 +33,11 @@ export const queryApiFromDocument = async <
       new Error('Finch is not currently listening for messages'),
     );
   }
-  const requestEvent = createRequestEvent(query, variables);
+  const requestEvent = createRequestEvent(
+    options?.extensionId,
+    query,
+    variables,
+  );
   const requestId = requestEvent.detail.requestId;
 
   return new Promise((resolve, reject) => {

--- a/src/external/types.ts
+++ b/src/external/types.ts
@@ -9,6 +9,7 @@ export interface FinchRequestEventProps {
   query: DocumentNode | string;
   variables?: any;
   requestId: string;
+  extensionId: string;
 }
 
 export type FinchRequestEvent = CustomEvent<FinchRequestEventProps>;

--- a/src/external/types.ts
+++ b/src/external/types.ts
@@ -1,0 +1,22 @@
+import { DocumentNode, GraphQLFormattedError } from 'graphql';
+
+export enum FinchDocumentEventNames {
+  Request = 'finch-document-request-event',
+  Response = 'finch-document-response-event',
+}
+
+export interface FinchRequestEventProps {
+  query: DocumentNode | string;
+  variables?: any;
+  requestId: string;
+}
+
+export type FinchRequestEvent = CustomEvent<FinchRequestEventProps>;
+
+export interface FinchResponseEventProps {
+  data: any;
+  errors?: Array<GraphQLFormattedError>;
+  requestId: string;
+}
+
+export type FinchResponseEvent = CustomEvent<FinchResponseEventProps>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export * from './background';
 export * from './client';
 export * from './types';
+export * from './external';
 export { ExtensionProvider, useExtension } from './hooks/ExtensionProvider';
 export { useQuery } from './hooks/useQuery';
 export { useMutation } from './hooks/useMutation';

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,12 +49,14 @@ export interface FinchMessage<Variables extends GenericVariables = {}> {
   type?: FinchMessageKey.Generic | string;
   query?: string | DocumentNode;
   variables?: Variables;
+  external?: boolean;
 }
 
 export interface FinchQueryOptions {
   id?: string;
   port?: browser.runtime.Port;
   messageKey?: string;
+  external?: boolean;
 }
 
 export interface FinchExecutionResults<Query> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9106,7 +9106,7 @@ uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.3.0:
+uuid@^8.3.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
## Description

<!--
  Description: [REQUIRED]
  Please include a summary of the feature and the change which were created
  to ensure readers of this pull request know what they are looking at.
-->

This adds in [external messaging](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/externally_connectable) support for browsers like Safari and Firefox where there is no support for things like external messaging. This adds listening for document events in an injected script and then the clients now can send those document events, with the graphQL queries, through the client APIs. 

This is the intended usage. This should seem like just a little code since all this does is enhances the capabilities of Finch.

```javascript
// Add to a special external connection bundle
// that is only injected into connectable sites
import { listenForDocumentQueries } from 'finch-graphql'

listenForDocumentQueries({ messageKey: 'myCustomKey' });
```

There should be no other changes needed based on the current state of the PR since the client code for externally connectable sites will automatically get this functionality.

### Questions or stuff to still work out

I still would like to work a few things out before merging.

* ~How do we make sure that we lock down who the website is talking to? Eg. Should the id of the extension be checked before sending messages to the extension? Should this be configurable?
  Would love to discuss some of the trade-offs. I think there may be some benefits not locking it down to extension id so it's easier to test things as production builds without having to build using production keys.~
* ~External sources should be represented in the context of the background script. Right now these messages look like they are coming from the extension itself.~
* How do we lock down messages to host that we want? Only inject this into hosts we want? Pass externally connectable sites to FinchApi?
* ~We should probably make a more explicit way of denoting that the website should be making this type of request. Eg. Right now we look for the id being passed as an indicator that this is indeed something external to the extension.~ We should just attempt all ways available. 

### Things needed to add.

- ~Add in origin to context~
- ~Add external source to context~
- ~Pass extension id through document events~
- ~Validate extension id on the listener~

## Testing

<!--
  Testing: [Required]
  If you did not write any tests that are in your code please describe how
  you ensured this code does what the description says it does. You may be
  asked in the PR how you tested the feature if you do not fill this out.
-->

- [x] Includes test.
- [ ] Manually tested.

## Additional notes

<!--
  Additional notes: [Optional]
  Anything additional like if you had to refactor something, or if
  an additional dependency is being added and why.
-->
