### PR TITLE
Add in message viewer

### DIFF
--- a/packages/finch-graphql-devtools/app/pages/devtoolsPanel.html
+++ b/packages/finch-graphql-devtools/app/pages/devtoolsPanel.html
@@ -1,13 +1,16 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8" />
   <title>Devtools</title>
   <link href="https://unpkg.com/graphiql/graphiql.min.css" rel="stylesheet" />
   <link rel="stylesheet" type="text/css" href="../styles/devtools.css">
 </head>
+
 <body>
   <div id="root"></div>
   <script src="../scripts/devtoolsPanel.js"></script>
 </body>
+
 </html>

--- a/packages/finch-graphql-devtools/app/scripts/components/Code.jsx
+++ b/packages/finch-graphql-devtools/app/scripts/components/Code.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { Box } from '@chakra-ui/react'
+
+export const Code = ({ code }) => {
+  return (
+    <Box as="pre" p={4} rounded={8} mb={3} overflow="scroll">
+      <Box as="code" color="blue.500" overflow="scroll">
+        {code}
+      </Box>
+    </Box>
+  )
+}

--- a/packages/finch-graphql-devtools/app/scripts/components/DevtoolsApp.jsx
+++ b/packages/finch-graphql-devtools/app/scripts/components/DevtoolsApp.jsx
@@ -7,6 +7,7 @@ import { SettingsEditor } from './SettingsEditor'
 import { StorageKey, DefaultQuery } from '../constants'
 import { useLocalStorage } from '../hooks/useLocalStorage'
 import { Theme } from './Theme'
+import { MessagesViewer } from './MessageViewer'
 
 export const graphQLFetcher = ({ messageKey, extensionId }) => async ({
   query,
@@ -39,13 +40,19 @@ export const DevtoolsApp = () => {
         colorScheme="blue"
         onChange={index => setTabIndex(index)}
         defaultIndex={tabIndex}
+        display="flex"
+        flexDirection="column"
+        height="100%"
       >
         <Header />
-        <TabPanels>
-          <TabPanel p="0">
+        <TabPanels display="flex" flexDirection="column" height="100%">
+          <TabPanel p="0" height="100%">
             <GraphiQL fetcher={fetcher} defaultQuery={DefaultQuery} />
           </TabPanel>
-          <TabPanel p="0">
+          <TabPanel p="0" height="100%">
+            <MessagesViewer extensionId={extensionId} messageKey={messageKey} />
+          </TabPanel>
+          <TabPanel p="0" height="100%">
             <SettingsEditor
               extensionId={extensionId}
               onChangeExtensionId={id => {

--- a/packages/finch-graphql-devtools/app/scripts/components/Header.jsx
+++ b/packages/finch-graphql-devtools/app/scripts/components/Header.jsx
@@ -9,6 +9,8 @@ export const Header = () => {
       display="flex"
       flexDirection="row"
       backgroundColor="white"
+      position="sticky"
+      top="0"
     >
       <TabList flex="1">
         <Box display="flex" alignItems="center" px={3}>
@@ -24,6 +26,7 @@ export const Header = () => {
             Graph<em>i</em>QL
           </span>
         </Tab>
+        <Tab>Messages</Tab>
         <Tab>Settings</Tab>
         <Box
           flex="1"

--- a/packages/finch-graphql-devtools/app/scripts/components/MessageViewer/MessageContent.jsx
+++ b/packages/finch-graphql-devtools/app/scripts/components/MessageViewer/MessageContent.jsx
@@ -1,0 +1,92 @@
+import React from 'react'
+import {
+  Box,
+  Text,
+  Heading,
+  Accordion,
+  AccordionButton,
+  AccordionIcon,
+  AccordionItem,
+  Tag,
+  useAccordionContext,
+} from '@chakra-ui/react'
+import { Code } from '../Code'
+import { formatJSON } from './helpers'
+
+export const MessageAccordionItem = ({ children, title, index }) => {
+  const { index: selectedIndex } = useAccordionContext()
+  const isOpen = index === selectedIndex
+
+  return (
+    <AccordionItem
+      display="flex"
+      flex={isOpen ? '1' : ''}
+      flexDirection="column"
+      overflow={isOpen ? 'scroll' : 'hidden'}
+    >
+      <Heading size="sm" flex="0">
+        <AccordionButton>
+          <Box flex="1" textAlign="left">
+            {title}
+          </Box>
+          <AccordionIcon />
+        </AccordionButton>
+      </Heading>
+      <Box
+        display={isOpen ? 'flex' : 'none'}
+        flexDirection="column"
+        backgroundColor="white"
+        flex="1"
+        flexBasis="1px"
+        overflow="scroll"
+      >
+        {children}
+      </Box>
+    </AccordionItem>
+  )
+}
+
+export const MessageContent = ({ message }) => {
+  const hasErrors =
+    message && message.response.errors && message.response.errors.length
+  return (
+    <Box flex={1} display="flex" flexDirection="column">
+      {message && (
+        <Box flex="1" display="flex" flexDirection="column">
+          <Box display="flex" flexDirection="column" pl={4} pt={6} pb={4}>
+            <Box display="flex" alignItems="center" pb={2}>
+              <Tag backgroundColor={hasErrors ? 'red.200' : 'teal.200'} mr={2}>
+                {hasErrors ? 'ERROR' : 'OK'}
+              </Tag>
+              <Heading size="md" flex="0">
+                {message.operationName}
+              </Heading>
+            </Box>
+            <Text pb={1}>
+              <strong>Time taken:</strong> {message.timeTaken}ms
+            </Text>
+            <Text>
+              <strong>Started at:</strong>{' '}
+              {new Date(message.initializedAt).toISOString()}
+            </Text>
+          </Box>
+          <Accordion allowToggle flex="1" display="flex" flexDirection="column">
+            <MessageAccordionItem title="Query" index={0}>
+              <Code code={message.rawQuery} mode="graphql" />
+            </MessageAccordionItem>
+            <MessageAccordionItem title="Variables" index={1}>
+              <Code code={formatJSON(message.variables)} mode="javascript" />
+            </MessageAccordionItem>
+
+            <MessageAccordionItem title="Response" index={2}>
+              <Code code={formatJSON(message.response)} mode="javascript" />
+            </MessageAccordionItem>
+            <MessageAccordionItem title="Context" index={3}>
+              <Code code={formatJSON(message.context)} mode="javascript" />
+            </MessageAccordionItem>
+          </Accordion>
+        </Box>
+      )}
+    </Box>
+  )
+}

--- a/packages/finch-graphql-devtools/app/scripts/components/MessageViewer/MessageSidebar.jsx
+++ b/packages/finch-graphql-devtools/app/scripts/components/MessageViewer/MessageSidebar.jsx
@@ -1,0 +1,141 @@
+import React from 'react'
+import { Box, Text, Heading, Tag, Divider } from '@chakra-ui/react'
+import { AutoSizer, List } from 'react-virtualized'
+
+export const renderListItem = ({ messages, selectQuery, selectedQuery }) => ({
+  index,
+  key,
+  style,
+}) => {
+  const message = messages[index]
+
+  if (!message) {
+    return null
+  }
+
+  const { response, operationName, timeTaken } = message
+
+  const hasErrors = response && response.errors && response.errors.length
+  return (
+    <Box style={style} key={key}>
+      <Box
+        py={2}
+        onClick={() => {
+          selectQuery(index)
+        }}
+        cursor="pointer"
+        display="flex"
+        flexDirection="column"
+        backgroundColor={selectedQuery === index ? 'teal.100' : 'white'}
+      >
+        <Box display="flex" flexDirection="row" alignItems="center" px={4}>
+          <Tag backgroundColor={hasErrors ? 'red.200' : 'teal.200'} mr={2}>
+            {hasErrors ? 'ERROR' : 'OK'}
+          </Tag>
+          <Text
+            size="sm"
+            overflow="hidden"
+            textOverflow="ellipsis"
+            whiteSpace="nowrap"
+            flex={1}
+          >
+            {operationName}
+          </Text>
+          <Text
+            size="sm"
+            overflow="hidden"
+            textOverflow="ellipsis"
+            whiteSpace="nowrap"
+          >
+            {timeTaken}ms
+          </Text>
+        </Box>
+      </Box>
+      <Divider />
+    </Box>
+  )
+}
+
+export const MessagesSidebar = ({ messages, selectQuery, selectedQuery }) => {
+  const renderer = renderListItem({ messages, selectQuery, selectedQuery })
+  console.log({ messages, selectQuery })
+
+  return (
+    <Box flex={1} maxWidth="250px" overflow="scroll">
+      <Box zIndex={2} position="sticky" top="0" backgroundColor="white">
+        <Box
+          px={4}
+          py={2}
+          cursor="pointer"
+          display="flex"
+          flexDirection="column"
+        >
+          <Heading size="sm">Messages</Heading>
+        </Box>
+        <Divider />
+      </Box>
+      <AutoSizer>
+        {({ width, height }) => (
+          <List
+            ref="message-list"
+            width={width}
+            height={height}
+            rowCount={messages.length}
+            rowRenderer={renderer}
+            rowHeight={41}
+          />
+        )}
+        {/* {messages.map(({ operationName, response, timeTaken }, i) => {
+          const hasErrors =
+            response && response.errors && response.errors.length
+          return (
+            <React.Fragment key={`message-${i}`}>
+              <Box
+                py={2}
+                onClick={() => {
+                  selectQuery(i)
+                }}
+                cursor="pointer"
+                display="flex"
+                flexDirection="column"
+                backgroundColor={selectedQuery === i ? 'teal.100' : 'white'}
+              >
+                <Box
+                  display="flex"
+                  flexDirection="row"
+                  alignItems="center"
+                  px={4}
+                >
+                  <Tag
+                    backgroundColor={hasErrors ? 'red.200' : 'teal.200'}
+                    mr={2}
+                  >
+                    {hasErrors ? 'ERROR' : 'OK'}
+                  </Tag>
+                  <Text
+                    size="sm"
+                    overflow="hidden"
+                    textOverflow="ellipsis"
+                    whiteSpace="nowrap"
+                    flex={1}
+                  >
+                    {operationName}
+                  </Text>
+                  <Text
+                    size="sm"
+                    overflow="hidden"
+                    textOverflow="ellipsis"
+                    whiteSpace="nowrap"
+                  >
+                    {timeTaken}ms
+                  </Text>
+                </Box>
+              </Box>
+              <Divider />
+            </React.Fragment>
+          )
+        })} */}
+      </AutoSizer>
+    </Box>
+  )
+}

--- a/packages/finch-graphql-devtools/app/scripts/components/MessageViewer/MessageSidebar.jsx
+++ b/packages/finch-graphql-devtools/app/scripts/components/MessageViewer/MessageSidebar.jsx
@@ -85,56 +85,6 @@ export const MessagesSidebar = ({ messages, selectQuery, selectedQuery }) => {
             rowHeight={41}
           />
         )}
-        {/* {messages.map(({ operationName, response, timeTaken }, i) => {
-          const hasErrors =
-            response && response.errors && response.errors.length
-          return (
-            <React.Fragment key={`message-${i}`}>
-              <Box
-                py={2}
-                onClick={() => {
-                  selectQuery(i)
-                }}
-                cursor="pointer"
-                display="flex"
-                flexDirection="column"
-                backgroundColor={selectedQuery === i ? 'teal.100' : 'white'}
-              >
-                <Box
-                  display="flex"
-                  flexDirection="row"
-                  alignItems="center"
-                  px={4}
-                >
-                  <Tag
-                    backgroundColor={hasErrors ? 'red.200' : 'teal.200'}
-                    mr={2}
-                  >
-                    {hasErrors ? 'ERROR' : 'OK'}
-                  </Tag>
-                  <Text
-                    size="sm"
-                    overflow="hidden"
-                    textOverflow="ellipsis"
-                    whiteSpace="nowrap"
-                    flex={1}
-                  >
-                    {operationName}
-                  </Text>
-                  <Text
-                    size="sm"
-                    overflow="hidden"
-                    textOverflow="ellipsis"
-                    whiteSpace="nowrap"
-                  >
-                    {timeTaken}ms
-                  </Text>
-                </Box>
-              </Box>
-              <Divider />
-            </React.Fragment>
-          )
-        })} */}
       </AutoSizer>
     </Box>
   )

--- a/packages/finch-graphql-devtools/app/scripts/components/MessageViewer/MessageSidebar.jsx
+++ b/packages/finch-graphql-devtools/app/scripts/components/MessageViewer/MessageSidebar.jsx
@@ -58,7 +58,6 @@ export const renderListItem = ({ messages, selectQuery, selectedQuery }) => ({
 
 export const MessagesSidebar = ({ messages, selectQuery, selectedQuery }) => {
   const renderer = renderListItem({ messages, selectQuery, selectedQuery })
-  console.log({ messages, selectQuery })
 
   return (
     <Box flex={1} maxWidth="250px" overflow="scroll">

--- a/packages/finch-graphql-devtools/app/scripts/components/MessageViewer/MessagesViewer.jsx
+++ b/packages/finch-graphql-devtools/app/scripts/components/MessageViewer/MessagesViewer.jsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react'
+import { Box } from '@chakra-ui/react'
+import { useEffect } from 'react'
+import { queryApi } from 'finch-graphql'
+import { EnableMessagesDoc, MessagePullQueryDoc } from './graphql'
+import { safeParse } from './helpers'
+import { MessageContent } from './MessageContent'
+import { MessagesSidebar } from './MessageSidebar'
+
+const TIMEOUT_SPEED = 1000
+
+export const MessagesViewer = ({
+  extensionId,
+  messageKey,
+  timeoutSpeed = TIMEOUT_SPEED,
+}) => {
+  const [messages, setMessages] = useState([])
+  const [selectedQuery, selectQuery] = useState(null)
+
+  const selectedQueryMessage = messages[selectedQuery]
+
+  const appendMessages = newMessages => {
+    const parsedMessages = newMessages.map(props => ({
+      ...props,
+      variables: safeParse(props.variables),
+      response: safeParse(props.response),
+      context: safeParse(props.context),
+    }))
+    setMessages(existingMessages => [...existingMessages, ...parsedMessages])
+  }
+
+  useEffect(() => {
+    let timer = 0
+
+    const runQuery = async () => {
+      try {
+        const resp = await queryApi(
+          MessagePullQueryDoc,
+          {},
+          { id: extensionId, messageKey },
+        )
+        if (resp && !resp.data._finchDevtools.enabled) {
+          await queryApi(EnableMessagesDoc, {}, { id: extensionId, messageKey })
+        }
+        if (
+          resp &&
+          resp.data._finchDevtools.messages &&
+          resp.data._finchDevtools.messages.length
+        ) {
+          appendMessages(resp.data._finchDevtools.messages)
+        }
+      } catch (e) {
+        console.error(e)
+      }
+      timer = setTimeout(runQuery, timeoutSpeed)
+    }
+
+    timer = setTimeout(runQuery, timeoutSpeed)
+    return () => {
+      clearInterval(timer)
+    }
+  }, [])
+
+  return (
+    <Box display="flex" height="100%" backgroundColor="white">
+      <MessagesSidebar
+        messages={messages}
+        selectedQuery={selectedQuery}
+        selectQuery={selectQuery}
+      />
+      <Box backgroundColor="grey.100" pr={0.2} flex={0} zIndex={2} />
+      <MessageContent message={selectedQueryMessage} />
+    </Box>
+  )
+}

--- a/packages/finch-graphql-devtools/app/scripts/components/MessageViewer/graphql.js
+++ b/packages/finch-graphql-devtools/app/scripts/components/MessageViewer/graphql.js
@@ -1,0 +1,24 @@
+import gql from 'graphql-tag'
+
+export const MessagePullQueryDoc = gql`
+  query getMessages {
+    _finchDevtools {
+      enabled
+      messages {
+        operationName
+        rawQuery
+        variables
+        initializedAt
+        timeTaken
+        response
+        context
+      }
+    }
+  }
+`
+
+export const EnableMessagesDoc = gql`
+  mutation enableMessages {
+    _enableFinchDevtools(enabled: true)
+  }
+`

--- a/packages/finch-graphql-devtools/app/scripts/components/MessageViewer/helpers.js
+++ b/packages/finch-graphql-devtools/app/scripts/components/MessageViewer/helpers.js
@@ -1,0 +1,11 @@
+export const formatJSON = json => {
+  return JSON.stringify(json, null, ' ')
+}
+
+export const safeParse = json => {
+  try {
+    return JSON.parse(json)
+  } catch (e) {
+    return {}
+  }
+}

--- a/packages/finch-graphql-devtools/app/scripts/components/MessageViewer/index.js
+++ b/packages/finch-graphql-devtools/app/scripts/components/MessageViewer/index.js
@@ -1,0 +1,1 @@
+export { MessagesViewer } from './MessagesViewer'

--- a/packages/finch-graphql-devtools/app/scripts/hooks/useInstalledExtensions.js
+++ b/packages/finch-graphql-devtools/app/scripts/hooks/useInstalledExtensions.js
@@ -28,8 +28,6 @@ export const useInstalledExtensions = () => {
     RequestManagementPermissionDoc,
   )
 
-  console.log(data, error)
-
   return {
     extensions: (data && data.extensions) || [],
     loading,

--- a/packages/finch-graphql-devtools/package.json
+++ b/packages/finch-graphql-devtools/package.json
@@ -10,6 +10,7 @@
     "webextension-toolbox": "latest"
   },
   "dependencies": {
+    "@chakra-ui/icons": "^1.0.13",
     "@chakra-ui/react": "^1.1.6",
     "@emotion/react": "^11.1.4",
     "@emotion/styled": "^11.0.0",
@@ -22,6 +23,7 @@
     "graphql-tag": "^2.11.0",
     "prop-types": "^15.7.2",
     "react": "^17.0.1",
-    "react-dom": "^17.0.1"
+    "react-dom": "^17.0.1",
+    "react-virtualized": "^9.22.3"
   }
 }

--- a/packages/finch-graphql/src/background/FinchDevtools.ts
+++ b/packages/finch-graphql/src/background/FinchDevtools.ts
@@ -1,0 +1,94 @@
+import { DocumentNode, print } from 'graphql';
+import gql from 'graphql-tag';
+import { FinchContextObj } from '../types';
+
+interface MessageMeta {
+  query: DocumentNode;
+  operationName: string | undefined;
+  context: FinchContextObj;
+  timeTaken: number;
+  response: any;
+  variables: any;
+}
+
+interface MessageCache {
+  operationName: String;
+  rawQuery: string;
+  variables: string;
+  initializedAt: number;
+  timeTaken: number;
+  response: string;
+  context: string;
+}
+
+let requests: Array<MessageCache> = [];
+let enabled: boolean = false;
+
+export const finchDevtoolsOnResponse = async ({
+  query,
+  operationName,
+  timeTaken,
+  response,
+  variables,
+  context,
+}: MessageMeta) => {
+  if (
+    enabled &&
+    operationName !== 'getMessages' &&
+    operationName !== 'enableMessages'
+  ) {
+    requests.push({
+      rawQuery: print(query),
+      operationName: operationName ?? 'unknown',
+      timeTaken,
+      initializedAt: Date.now() - timeTaken,
+      response: JSON.stringify(response),
+      variables: JSON.stringify(variables),
+      context: JSON.stringify(context),
+    });
+  }
+};
+
+export const finchDevtoolsResolvers = {
+  Query: {
+    _finchDevtools: () => {
+      const currentRequests = [...requests];
+      requests = [];
+      return {
+        enabled,
+        messages: currentRequests,
+      };
+    },
+  },
+  Mutation: {
+    _enableFinchDevtools: () => {
+      enabled = true;
+      return true;
+    },
+  },
+};
+
+export const finchDevtoolsSchema = gql`
+  type FinchMessage {
+    operationName: String
+    rawQuery: String!
+    variables: String
+    initializedAt: Float!
+    timeTaken: Float!
+    response: String!
+    context: String!
+  }
+
+  type FinchDevtools {
+    enabled: Boolean!
+    messages: [FinchMessage!]!
+  }
+
+  extend type Query {
+    _finchDevtools: FinchDevtools
+  }
+
+  extend type Mutation {
+    _enableFinchDevtools(enabled: Boolean!): Boolean!
+  }
+`;

--- a/packages/finch-graphql/src/background/index.ts
+++ b/packages/finch-graphql/src/background/index.ts
@@ -1,2 +1,7 @@
 export { FinchApi } from './FinchApi';
 export { NoIntrospection } from './NoIntrospection';
+export {
+  finchDevtoolsOnResponse,
+  finchDevtoolsResolvers,
+  finchDevtoolsSchema,
+} from './FinchDevtools';

--- a/packages/finch-graphql/src/client/hooks/useQuery.test.ts
+++ b/packages/finch-graphql/src/client/hooks/useQuery.test.ts
@@ -152,7 +152,9 @@ describe('useQuery', () => {
   it('should update the cache values when the cache values are updated', async () => {
     const sendMessageMock = jest
       .fn()
-      .mockImplementationOnce((_, callback) => callback({ bar: 'baz' }));
+      .mockImplementationOnce((_, callback) =>
+        callback({ data: { bar: 'baz' } }),
+      );
     chrome.runtime.sendMessage = sendMessageMock;
 
     const client = new FinchClient({
@@ -183,7 +185,7 @@ describe('useQuery', () => {
     await act(async () => {
       // Change the response
       sendMessageMock.mockImplementationOnce((_, callback) =>
-        callback({ bar: 'qux' }),
+        callback({ data: { bar: 'qux' } }),
       );
       await client.query(testDoc, { foo: 'bar' });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1619,6 +1619,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.8.7":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.0.tgz#46794bc20b612c5f75e62dd071e24dfd95f1cbe6"
+  integrity sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.1.2", "@babel/template@^7.12.13", "@babel/template@^7.12.7", "@babel/template@^7.3.3":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"
@@ -1814,6 +1821,21 @@
   integrity sha512-VLZ0xiEbjYL7bM0zYxOvpd0f8ovu9NsekovV5jHO4J1hooCawuwh43OFYjIzyMzCwwTdsdolMB+c5WsZRnsW+Q==
   dependencies:
     "@chakra-ui/utils" "1.5.0"
+
+"@chakra-ui/icon@1.1.9":
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/icon/-/icon-1.1.9.tgz#fbd6e82abf58b890f5bcc728bb75dda25d7b6c63"
+  integrity sha512-lmZHK4O+Wo7LwxRsQb0KmtOwq2iACESxwQgackuj7NPHbAsdF2/y3t2f7KCD+dTKGxoauEMgU2nVLePZWjtpTQ==
+  dependencies:
+    "@chakra-ui/utils" "1.8.0"
+
+"@chakra-ui/icons@^1.0.13":
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/icons/-/icons-1.0.13.tgz#d8eb04479b048d8023ae90d76205cd4a0bf7dd79"
+  integrity sha512-twDpFz2uPVboMTEI4QA2y3EJND3G4+/9AVs730fgnnfhTw4EOJt0Lhfm4Spq1qi1LgHF16x4/Lao1E2imB5lWw==
+  dependencies:
+    "@chakra-ui/icon" "1.1.9"
+    "@types/react" "^17.0.0"
 
 "@chakra-ui/image@1.0.10":
   version "1.0.10"
@@ -2172,6 +2194,16 @@
   dependencies:
     "@types/lodash.mergewith" "4.6.6"
     css-box-model "1.2.1"
+    lodash.mergewith "4.6.2"
+
+"@chakra-ui/utils@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/utils/-/utils-1.8.0.tgz#f7aad8175cc5a26a1d2795dc78691bbc21fd539e"
+  integrity sha512-BWIhKcXnLbOIwCTKeNcOStNwk9RyYVA9xRRFPGK6Kp3EhrxP0rDwAbu4D3o3qAc+yhIDhGmPaIj1jRXHB5DTfg==
+  dependencies:
+    "@types/lodash.mergewith" "4.6.6"
+    css-box-model "1.2.1"
+    framesync "5.3.0"
     lodash.mergewith "4.6.2"
 
 "@chakra-ui/visually-hidden@1.0.7":
@@ -6558,7 +6590,7 @@ clone@~0.1.9:
   resolved "https://registry.yarnpkg.com/clone/-/clone-0.1.19.tgz#613fb68639b26a494ac53253e15b1a6bd88ada85"
   integrity sha1-YT+2hjmyaklKxTJT4Vsaa9iK2oU=
 
-clsx@^1.1.1:
+clsx@^1.0.4, clsx@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
   integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
@@ -7834,6 +7866,14 @@ dom-converter@^0.2:
   integrity sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==
   dependencies:
     utila "~0.4"
+
+dom-helpers@^5.1.3:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
+  integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^3.0.2"
 
 dom-serializer@0:
   version "0.2.2"
@@ -14993,6 +15033,18 @@ react-textarea-autosize@^8.3.2:
     "@babel/runtime" "^7.10.2"
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
+
+react-virtualized@^9.22.3:
+  version "9.22.3"
+  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.22.3.tgz#f430f16beb0a42db420dbd4d340403c0de334421"
+  integrity sha512-MKovKMxWTcwPSxE1kK1HcheQTWfuCxAuBoSTf2gwyMM21NdX/PXUhnoP8Uc5dRKd+nKm8v41R36OellhdCpkrw==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    clsx "^1.0.4"
+    dom-helpers "^5.1.3"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-lifecycles-compat "^3.0.4"
 
 react@^17.0.1:
   version "17.0.2"


### PR DESCRIPTION
## Description

<!--
  Description: [REQUIRED]
  Please include a summary of the feature and the change which were created
  to ensure readers of this pull request know what they are looking at.
-->

This PR adds a message viewer to the debug tools. This allows use to see information about messages that are being passed through an extensions finch-graphql. This gives great insight to time taken on certain resolvers, and also what is the payload of those resolvers.

<img width="631" alt="Screen Shot 2021-05-31 at 8 31 30 PM" src="https://user-images.githubusercontent.com/578259/120329863-e1e7d900-c2b1-11eb-8ef4-ce4e2c10098e.png">


## Testing

<!--
  Testing: [Required]
  If you did not write any tests that are in your code please describe how
  you ensured this code does what the description says it does. You may be
  asked in the PR how you tested the feature if you do not fill this out.
-->

- [ ] Includes test.
- [x] Manually tested.

## Additional notes

<!--
  Additional notes: [Optional]
  Anything additional like if you had to refactor something, or if
  an additional dependency is being added and why.
-->

Really thinking after this feature we should probably spend some time to convert this devtools to typescript.
