### PR TITLE
Devtools settings and message tab fixes.

### DIFF
--- a/packages/finch-graphql-devtools/app/manifest.json
+++ b/packages/finch-graphql-devtools/app/manifest.json
@@ -2,7 +2,7 @@
   "name": "__MSG_appName__",
   "short_name": "__MSG_appShortName__",
   "description": "__MSG_appDescription__",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "manifest_version": 2,
   "default_locale": "en",
   "icons": {

--- a/packages/finch-graphql-devtools/app/scripts/components/DevtoolsApp.jsx
+++ b/packages/finch-graphql-devtools/app/scripts/components/DevtoolsApp.jsx
@@ -56,7 +56,11 @@ export const DevtoolsApp = () => {
             <SettingsEditor
               extensionId={extensionId}
               onChangeExtensionId={id => {
-                setExtensionId(id)
+                if (typeof id === 'string') {
+                  setExtensionId(id)
+                } else {
+                  setExtensionId(id.target.value)
+                }
               }}
               messageKey={messageKey}
               onChangeMessageKey={e => {

--- a/packages/finch-graphql-devtools/app/scripts/components/MessageViewer/MessagesViewer.jsx
+++ b/packages/finch-graphql-devtools/app/scripts/components/MessageViewer/MessagesViewer.jsx
@@ -8,6 +8,7 @@ import { MessageContent } from './MessageContent'
 import { MessagesSidebar } from './MessageSidebar'
 import { MessagesFilterBar } from './MessagesFilterBar'
 import { useLocalStorage } from '../../hooks/useLocalStorage'
+import { v4 } from 'uuid'
 
 const TIMEOUT_SPEED = 1000
 
@@ -36,7 +37,7 @@ export const MessagesViewer = ({
       variables: safeParse(props.variables),
       response: safeParse(props.response),
       context: safeParse(props.context),
-      id: `${props.operationName}:${i + messages.length}`,
+      id: v4(),
     }))
     setMessages(existingMessages => [...existingMessages, ...parsedMessages])
   }

--- a/packages/finch-graphql-devtools/app/scripts/components/SettingsEditor.jsx
+++ b/packages/finch-graphql-devtools/app/scripts/components/SettingsEditor.jsx
@@ -153,7 +153,9 @@ export const SettingsEditor = ({
             <Button
               onClick={async () => {
                 await requestManagementPermission({})
-                await refetch()
+                setTimeout(() => {
+                  window.location.reload()
+                }, 300)
               }}
               colorScheme="blue"
               color="white"

--- a/packages/finch-graphql-devtools/app/scripts/resolvers/extensions.js
+++ b/packages/finch-graphql-devtools/app/scripts/resolvers/extensions.js
@@ -27,7 +27,13 @@ export const extensionResolvers = {
   },
   Mutation: {
     requestManagementPermission: async () => {
-      return browser.permissions.request({ permissions: ['management'] })
+      const resp = await browser.permissions.request({
+        permissions: ['management'],
+      })
+      if (resp) {
+        browser.runtime.reload()
+      }
+      return true
     },
   },
 }

--- a/packages/finch-graphql-devtools/package.json
+++ b/packages/finch-graphql-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "finch-graphql-devtools",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Finch GraphQL devtools is an extension that will allow you to query a Finch GraphQL background process to be able to debug the schema, query, and mutate data in the extension.",
   "scripts": {
     "dev": "webextension-toolbox dev",

--- a/packages/finch-graphql-devtools/package.json
+++ b/packages/finch-graphql-devtools/package.json
@@ -24,6 +24,7 @@
     "prop-types": "^15.7.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "react-virtualized": "^9.22.3"
+    "react-virtualized": "^9.22.3",
+    "uuid": "^8.3.2"
   }
 }


### PR DESCRIPTION
## Description

<!--
  Description: [REQUIRED]
  Please include a summary of the feature and the change which were created
  to ensure readers of this pull request know what they are looking at.
-->

This PR adds some fixes to the settings, and messages tab of the devtools. Settings had two bugs: ID not being able to be set and also after allowing the managment API the results would not come back until there was a reload of the background page. Messages had a issue where two or more messages could be selected at the same time.

* closes #140
* closes #141

## Testing

<!--
  Testing: [Required]
  If you did not write any tests that are in your code please describe how
  you ensured this code does what the description says it does. You may be
  asked in the PR how you tested the feature if you do not fill this out.
-->

- [ ] Includes test.
- [x] Manually tested.

## Additional notes

<!--
  Additional notes: [Optional]
  Anything additional like if you had to refactor something, or if
  an additional dependency is being added and why.
-->

_No additional information is given_
