### PR TITLE
Fix extension list on initial install

### DIFF
--- a/apps/devtools/app/scripts/components/ExtensionSwitcher/ExtensionSwitcher.tsx
+++ b/apps/devtools/app/scripts/components/ExtensionSwitcher/ExtensionSwitcher.tsx
@@ -127,8 +127,8 @@ export const ExtensionSwitcher: FC<ExtensionSwitcherProps> = ({
             </Box>
             {hasManagementPermission ? (
               <>
-                {extensionInfo && (
-                  <>
+                <>
+                  {extensionInfo && (
                     <CurrentExtension
                       {...extensionInfo}
                       isConnected={isConnected}
@@ -143,13 +143,13 @@ export const ExtensionSwitcher: FC<ExtensionSwitcherProps> = ({
                         connectionInfo={connectionInfo}
                       />
                     </CurrentExtension>
-                    <ExtensionList
-                      hasCurrentExtension={!!extensionInfo}
-                      currentExtensionId={extensionId}
-                      setExtensionId={setExtensionId}
-                    />
-                  </>
-                )}
+                  )}
+                  <ExtensionList
+                    hasCurrentExtension={!!extensionInfo}
+                    currentExtensionId={extensionId}
+                    setExtensionId={setExtensionId}
+                  />
+                </>
               </>
             ) : (
               <NoPermissionDrawer>


### PR DESCRIPTION
## Description

<!--
  Description: [REQUIRED]
  Please include a summary of the feature and the change which were created
  to ensure readers of this pull request know what they are looking at.
-->

This PR fixes an issue of not being able to see the initial extension list when no extension is selected.

## Testing

<!--
  Testing: [Required]
  If you did not write any tests that are in your code please describe how
  you ensured this code does what the description says it does. You may be
  asked in the PR how you tested the feature if you do not fill this out.
-->

- [ ] Includes test.
- [x] Manually tested.

Overall need to get to a point where we start testing this functionality

## Additional notes

<!--
  Additional notes: [Optional]
  Anything additional like if you had to refactor something, or if
  an additional dependency is being added and why.
-->

_No additional information is given_
