### PR TITLE
[bug] wrap connection listener in a try/catch

### DIFF
--- a/packages/api/src/background/FinchPortConnection.ts
+++ b/packages/api/src/background/FinchPortConnection.ts
@@ -135,9 +135,14 @@ export class FinchPortConnection implements FinchConnection {
      * modify the unbind method to remove the listeners that we created.
      */
     this.unbind = () => {
-      removeConnectListener(internalConnectionHandler);
-      if (external) {
-        removeConnectExternalListener(externalConnectionHandler);
+      try {
+        removeConnectListener(internalConnectionHandler);
+        if (external) {
+          removeConnectExternalListener(externalConnectionHandler);
+        }
+      } catch (e) {
+        // catching when port has already been disconnected.
+        // do nothing.
       }
     };
   }


### PR DESCRIPTION
## Description

<!--
  Description: [REQUIRED]
  Please include a summary of the feature and the change which were created
  to ensure readers of this pull request know what they are looking at.
-->

Wrapping the removal of a connection listener in a `try/catch` statement to help reduce the number of errors that get logged when the port has already been disconnected.

## Testing

<!--
  Testing: [Required]
  If you did not write any tests that are in your code please describe how
  you ensured this code does what the description says it does. You may be
  asked in the PR how you tested the feature if you do not fill this out.
-->

- [ ] Includes test.
- [ ] Manually tested.

## Additional notes

<!--
  Additional notes: [Optional]
  Anything additional like if you had to refactor something, or if
  an additional dependency is being added and why.
-->

_No additional information is given_
