### PR TITLE
Fix issue with GraphiQL not being able to query extension

### DIFF
--- a/apps/devtools/app/scripts/components/DevtoolsApp.tsx
+++ b/apps/devtools/app/scripts/components/DevtoolsApp.tsx
@@ -59,24 +59,11 @@ export const DevtoolsApp = () => {
   );
 
   const graphQLFetcher = useCallback(
-    ({
-      messageKey: fetcherMessageKey,
-      extensionId: fetcherExtensionId,
-    }: {
-      messageKey: string;
-      extensionId: string;
-    }): Fetcher => async ({ query, variables }) => {
-      return externalClient.queryApi(query, variables || {}, {
-        messageKey: fetcherMessageKey,
-        id: fetcherExtensionId,
-      });
+    async ({ query, variables }) => {
+      return externalClient.mutate(query, variables || {});
     },
     [externalClient],
   );
-
-  const fetcher = useMemo(() => {
-    return graphQLFetcher({ messageKey, extensionId });
-  }, [messageKey, extensionId]);
 
   return (
     <FinchProvider client={client}>

--- a/apps/devtools/app/scripts/components/DevtoolsApp.tsx
+++ b/apps/devtools/app/scripts/components/DevtoolsApp.tsx
@@ -1,5 +1,5 @@
 import { FinchClient, FinchProvider } from '@finch-graphql/react';
-import { FinchMessageKey } from '@finch-graphql/types';
+import { FinchDefaultPortName, FinchMessageKey } from '@finch-graphql/types';
 import { useMemo, useState } from 'react';
 import { Tabs, TabPanels, TabPanel } from '@chakra-ui/react';
 import GraphiQL, { Fetcher } from 'graphiql';
@@ -34,7 +34,8 @@ export const DevtoolsApp = () => {
 
   const messageKey = extensionProfile.messageKey;
   const connectionType = extensionProfile.connectionType;
-  const messagePortName = extensionProfile.messagePortName;
+  const messagePortName =
+    extensionProfile.messagePortName ?? FinchDefaultPortName;
 
   // TODO need to destroy the client when new on is created
   const externalClient = useMemo(() => {
@@ -105,7 +106,7 @@ export const DevtoolsApp = () => {
         />
         <TabPanels display="flex" flexDirection="column" height="100%">
           <TabPanel p="0" height="100%">
-            <GraphiQL fetcher={fetcher} defaultQuery={DefaultQuery} />
+            <GraphiQL fetcher={graphQLFetcher} defaultQuery={DefaultQuery} />
           </TabPanel>
           <TabPanel p="0" height="100%">
             <MessagesViewer extensionId={extensionId} />

--- a/apps/devtools/app/scripts/components/DevtoolsApp.tsx
+++ b/apps/devtools/app/scripts/components/DevtoolsApp.tsx
@@ -2,7 +2,7 @@ import { FinchClient, FinchProvider } from '@finch-graphql/react';
 import { FinchDefaultPortName, FinchMessageKey } from '@finch-graphql/types';
 import { useMemo, useState } from 'react';
 import { Tabs, TabPanels, TabPanel } from '@chakra-ui/react';
-import GraphiQL, { Fetcher } from 'graphiql';
+import GraphiQL from 'graphiql';
 import { Header } from './Header';
 import { StorageKey, DefaultQuery } from '../constants';
 import { useLocalStorage } from '../hooks/useLocalStorage';

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -17,7 +17,8 @@
   "scripts": {
     "build": "tsc",
     "prepublish": "yarn build",
-    "test": "jest"
+    "test": "jest",
+    "dev": "tsc --watch"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.12.1",

--- a/packages/api/src/background/FinchApi.ts
+++ b/packages/api/src/background/FinchApi.ts
@@ -100,11 +100,9 @@ export class FinchApi {
      */
     if (!disableDevtools) {
       this.devtools = new FinchDevtools({
-        messageKey: disableIntrospection ? undefined : this.messageKey,
+        messageKey: this.messageKey,
         connectionType: this.connection.type,
-        messagePortName: disableIntrospection
-          ? undefined
-          : this.messagePortName,
+        messagePortName: this.messagePortName,
       });
       this.devtools.onStart();
     }

--- a/packages/browser-polyfill/package.json
+++ b/packages/browser-polyfill/package.json
@@ -18,7 +18,8 @@
     "build": "tsc",
     "prepublish": "yarn build",
     "test": "jest",
-    "lint": "eslint -c ./.eslintrc.js ./src/**/*.ts"
+    "lint": "eslint -c ./.eslintrc.js ./src/**/*.ts",
+    "dev": "tsc --watch"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.12.1",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -18,7 +18,8 @@
     "build": "tsc",
     "prepublish": "yarn build",
     "test": "jest",
-    "lint": "eslint -c ./.eslintrc.js ./src/**/*.ts"
+    "lint": "eslint -c ./.eslintrc.js ./src/**/*.ts",
+    "dev": "tsc --watch"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.12.1",

--- a/packages/client/src/client/FinchClient.ts
+++ b/packages/client/src/client/FinchClient.ts
@@ -131,7 +131,7 @@ export class FinchClient {
       const decoratedMessage = messageCreator(
         query,
         variables,
-        options.messageKey,
+        options.messageKey ?? this.messageKey,
         !!this.id,
       );
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -17,7 +17,8 @@
   "scripts": {
     "build": "tsc",
     "prepublish": "yarn build",
-    "test": "jest"
+    "test": "jest",
+    "dev": "tsc --watch"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.12.1",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -18,7 +18,8 @@
     "build": "tsc",
     "prepublish": "yarn build",
     "test": "echo \"No tests in types\"",
-    "lint": "eslint -c ./.eslintrc.js ./src/**/*.ts"
+    "lint": "eslint -c ./.eslintrc.js ./src/**/*.ts",
+    "dev": "tsc --watch"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.170",


### PR DESCRIPTION
## Description

<!--
  Description: [REQUIRED]
  Please include a summary of the feature and the change which were created
  to ensure readers of this pull request know what they are looking at.
-->

This PR fixes and issue where the GraphiQL client in the devtools was not able to communicate with the extension when introspection was disabled. Although this might be favorable in some situations it is unexpected. Since I would assume disabling introspection would just not make it so I can read the schema. This restores this functionality and cleans up some dev code.

## Testing

<!--
  Testing: [Required]
  If you did not write any tests that are in your code please describe how
  you ensured this code does what the description says it does. You may be
  asked in the PR how you tested the feature if you do not fill this out.
-->

- [ ] Includes test.
- [ ] Manually tested.

## Additional notes

<!--
  Additional notes: [Optional]
  Anything additional like if you had to refactor something, or if
  an additional dependency is being added and why.
-->

_No additional information is given_
