### PR TITLE
Add in ability to specify query timeout.

### DIFF
--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -64,6 +64,7 @@ export interface FinchQueryOptions {
   port?: browser.runtime.Port;
   messageKey?: string;
   external?: boolean;
+  timeout?: number;
 }
 
 export interface FinchExecutionResults<Query> {

--- a/packages/client/src/client/FinchClient.ts
+++ b/packages/client/src/client/FinchClient.ts
@@ -146,7 +146,7 @@ export class FinchClient {
             },
           ],
         });
-      }, this.messageTimeout);
+      }, options.timeout ?? this.messageTimeout);
 
       const onMessage = ({
         id,

--- a/packages/react/src/hooks/useQuery.ts
+++ b/packages/react/src/hooks/useQuery.ts
@@ -22,6 +22,7 @@ type QueryError = GraphQLFormattedError | Error;
  * @param options.skip if true, the query will not be run until true
  * @param options.pollInterval [optional] how often to poll the server for updates
  * @param options.poll [optional] not needed for simple polling queries but allows you turn off polling on mount
+ * @param options.timeout [optional] how long to wait for a response from the server before timing out, this is used only for port based connections overrides the global timeout
  * @returns the response, and loading states of the query.
  */
 export const useQuery = <Query, Variables>(

--- a/packages/react/src/hooks/useQuery.ts
+++ b/packages/react/src/hooks/useQuery.ts
@@ -8,6 +8,7 @@ interface BackgroundQueryOptions<Variables> {
   skip?: Boolean;
   pollInterval?: number;
   poll?: boolean;
+  timeout?: number;
 }
 
 type QueryError = GraphQLFormattedError | Error;
@@ -30,6 +31,7 @@ export const useQuery = <Query, Variables>(
     variables,
     pollInterval: passedPollInterval = 0,
     poll,
+    timeout,
   }: BackgroundQueryOptions<Variables> = {},
 ) => {
   const { client } = useFinchClient();
@@ -55,6 +57,7 @@ export const useQuery = <Query, Variables>(
           query,
           // @ts-ignore variables are kinda weird
           argVars ?? variables ?? {},
+          { timeout },
         );
 
         if (resp.data && mounted.current) {

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -65,6 +65,7 @@ export interface FinchQueryOptions {
   port?: browser.runtime.Port;
   messageKey?: string;
   external?: boolean;
+  timeout?: number;
 }
 
 export interface FinchExecutionResults<Query> {

--- a/packages/typescript-codegen/FinchVisitor.js
+++ b/packages/typescript-codegen/FinchVisitor.js
@@ -68,6 +68,7 @@ class FinchVisitor extends ClientSideBaseVisitor {
         skip?: Boolean;
         pollInterval?: number;
         poll?: boolean;
+        timeout?: number;
       }) => use${operationType}<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, config);`;
     }
     if (operationType === 'Mutation') {


### PR DESCRIPTION
<!-- - allow for the passing of timeout for individual queries
- add in some documentation
- add timeout to codegen -->

## Description

<!--
  Description: [REQUIRED]
  Please include a summary of the feature and the change which were created
  to ensure readers of this pull request know what they are looking at.
-->

This PR adds in the ability to set specific timeout for each query. This is super useful if you have some slower queries and want to give them more time to complete.

```typescript
client.query(Doc, {}, { timeout: 10000 });
// or
const { data } = useQuery(Doc, { timeout: 10000 });
```

## Testing

<!--
  Testing: [Required]
  If you did not write any tests that are in your code please describe how
  you ensured this code does what the description says it does. You may be
  asked in the PR how you tested the feature if you do not fill this out.
-->

- [ ] Includes test.
- [x] Manually tested.

## Additional notes

<!--
  Additional notes: [Optional]
  Anything additional like if you had to refactor something, or if
  an additional dependency is being added and why.
-->

_No additional information is given_
