### PR TITLE
Fix issue with port disconnect, and React 18 double fetch

### DIFF
--- a/packages/api/src/background/FinchPortConnection.ts
+++ b/packages/api/src/background/FinchPortConnection.ts
@@ -100,6 +100,8 @@ export class FinchPortConnection implements FinchConnection {
         return;
       }
 
+      let portDisconnected = false;
+
       this.messagePorts.push(port);
 
       /**
@@ -108,6 +110,7 @@ export class FinchPortConnection implements FinchConnection {
        * process shutting down the client will attempt to make another connection.
        */
       port.onDisconnect.addListener(() => {
+        portDisconnected = true;
         const portIndex = this.messagePorts.indexOf(port);
         if (portIndex === -1) {
           return;
@@ -121,6 +124,9 @@ export class FinchPortConnection implements FinchConnection {
        */
       port.onMessage.addListener((msg: AnyFinchMessage) => {
         this.messageListener(msg, port.sender).then(resp => {
+          if (portDisconnected) {
+            return;
+          }
           port.postMessage({ id: msg.id, ...resp, external: isExternal });
         });
       });


### PR DESCRIPTION
## Description

<!--
  Description: [REQUIRED]
  Please include a summary of the feature and the change which were created
  to ensure readers of this pull request know what they are looking at.
-->

This PR adds in a couple fixes.

- We had and issue where we would try to send messages to disconnected ports if the port was disconnected in the middle of a fetch.

![Screen Shot 2022-07-03 at 6 06 52 PM](https://user-images.githubusercontent.com/578259/177067145-0cc759b2-5560-433f-a4f5-d0bf3651c0c4.png)

- In React 18 we have and issue that it will make double queries. I have and update that makes this issue a little better but will need move the client to something more verbose to handle this in the future. The fix here just makes sure to not update state from prior fetches.

The larger fix for React 18 will be to make it so we can allow the client determine if it should refetch, right now this being in React land is causing the issue, and if we create an observable for the client to determine if it should refetch that might be better, though makes the finch client a lot more complicated.

## Testing

<!--
  Testing: [Required]
  If you did not write any tests that are in your code please describe how
  you ensured this code does what the description says it does. You may be
  asked in the PR how you tested the feature if you do not fill this out.
-->

- [x] Includes test.
- [x] Manually tested.


## Additional notes

<!--
  Additional notes: [Optional]
  Anything additional like if you had to refactor something, or if
  an additional dependency is being added and why.
-->

_No additional information is given_
