### PR TITLE
Reconnect orphaned ports

### DIFF
--- a/packages/client/src/client/FinchClient.test.ts
+++ b/packages/client/src/client/FinchClient.test.ts
@@ -1,0 +1,114 @@
+import { FinchClient, FinchClientStatus } from './FinchClient';
+
+describe('FinchClient', () => {
+  let mockPort: browser.runtime.Port;
+  let originalConnect: () => browser.runtime.Port;
+  beforeEach(() => {
+    originalConnect = browser.runtime.connect;
+    mockPort = {
+      name: 'mockPort',
+      disconnect: jest.fn(),
+      postMessage: jest.fn(),
+      onDisconnect: {
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        hasListener: jest.fn(),
+      },
+      onMessage: {
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        hasListener: jest.fn(),
+      },
+    };
+    browser.runtime.connect = jest.fn().mockImplementation(() => mockPort);
+  });
+  afterEach(() => {
+    browser.runtime.connect = originalConnect;
+  });
+
+  describe('a port connection', () => {
+    it('should attempt to connect a port if useMessages is false', () => {
+      const client = new FinchClient({
+        useMessages: false,
+        autoStart: true,
+      });
+      expect(browser.runtime.connect).toHaveBeenCalledTimes(1);
+      expect(mockPort.onDisconnect.addListener).toHaveBeenCalledTimes(1);
+      expect(client.status).toBe(FinchClientStatus.Connected);
+    });
+    it('should attach a message listener when a query is made', () => {
+      const client = new FinchClient({
+        useMessages: false,
+        autoStart: true,
+      });
+      client.query('query foo { bar }');
+      expect(mockPort.onMessage.addListener).toHaveBeenCalledTimes(1);
+    });
+    it('should detach a message listener when a query is resolved', async () => {
+      const client = new FinchClient({
+        useMessages: false,
+        autoStart: true,
+      });
+      let messageListener: (response: object) => void = jest.fn();
+      mockPort.onMessage.addListener = jest.fn(listener => {
+        messageListener = listener;
+      });
+      mockPort.postMessage = jest.fn();
+      const pendingQuery = client.query('query foo { bar }');
+      // @ts-ignore
+      const message = mockPort.postMessage.mock.calls[0][0];
+      const id = message.id;
+      messageListener({ id, data: 'foo' });
+      const resp = await pendingQuery;
+      expect(resp.data).toBe('foo');
+      expect(mockPort.onMessage.removeListener).toHaveBeenCalledTimes(1);
+    });
+    it('should timeout a query if no response is given after a certain time', async () => {
+      const client = new FinchClient({
+        useMessages: false,
+        autoStart: true,
+        messageTimeout: 0,
+      });
+      const resp = await client.query('query foo { bar }');
+      expect(resp.errors?.[0].message).toBe(
+        'Timed out waiting for response from background script',
+      );
+    });
+    it('should try to reconnect a port after a given number of timeouts', async () => {
+      const client = new FinchClient({
+        useMessages: false,
+        autoStart: true,
+        maxPortTimeoutCount: 2,
+        messageTimeout: 0,
+      });
+      expect(browser.runtime.connect).toHaveBeenCalledTimes(1);
+      await client.query('query foo { bar }');
+      await client.query('query foo { bar }');
+      expect(browser.runtime.connect).toHaveBeenCalledTimes(2);
+    });
+    it('should cancel any ongoing messages when a reconnect happens', async () => {
+      const client = new FinchClient({
+        useMessages: false,
+        autoStart: true,
+        maxPortTimeoutCount: 2,
+        messageTimeout: 0,
+      });
+      expect(browser.runtime.connect).toHaveBeenCalledTimes(1);
+      await client.query('query foo { bar }');
+      const timeoutPendingQuery = client.query(
+        'query foo { bar }',
+        {},
+        { timeout: 100 },
+      );
+      const pendingQuery = client.query(
+        'query foo { bar }',
+        {},
+        { timeout: 1000 },
+      );
+      await timeoutPendingQuery;
+      expect(browser.runtime.connect).toHaveBeenCalledTimes(2);
+      const resp = await pendingQuery;
+      expect(resp.errors?.[0].message).toBe('Promise cancelled');
+    });
+  });
+});

--- a/packages/client/src/client/FinchClient.test.ts
+++ b/packages/client/src/client/FinchClient.test.ts
@@ -1,32 +1,31 @@
 import { FinchClient, FinchClientStatus } from './FinchClient';
 
 describe('FinchClient', () => {
-  let mockPort: browser.runtime.Port;
-  let originalConnect: () => browser.runtime.Port;
-  beforeEach(() => {
-    originalConnect = browser.runtime.connect;
-    mockPort = {
-      name: 'mockPort',
-      disconnect: jest.fn(),
-      postMessage: jest.fn(),
-      onDisconnect: {
-        addListener: jest.fn(),
-        removeListener: jest.fn(),
-        hasListener: jest.fn(),
-      },
-      onMessage: {
-        addListener: jest.fn(),
-        removeListener: jest.fn(),
-        hasListener: jest.fn(),
-      },
-    };
-    browser.runtime.connect = jest.fn().mockImplementation(() => mockPort);
-  });
-  afterEach(() => {
-    browser.runtime.connect = originalConnect;
-  });
-
   describe('a port connection', () => {
+    let mockPort: browser.runtime.Port;
+    let originalConnect: () => browser.runtime.Port;
+    beforeEach(() => {
+      originalConnect = browser.runtime.connect;
+      mockPort = {
+        name: 'mockPort',
+        disconnect: jest.fn(),
+        postMessage: jest.fn(),
+        onDisconnect: {
+          addListener: jest.fn(),
+          removeListener: jest.fn(),
+          hasListener: jest.fn(),
+        },
+        onMessage: {
+          addListener: jest.fn(),
+          removeListener: jest.fn(),
+          hasListener: jest.fn(),
+        },
+      };
+      browser.runtime.connect = jest.fn().mockImplementation(() => mockPort);
+    });
+    afterEach(() => {
+      browser.runtime.connect = originalConnect;
+    });
     it('should attempt to connect a port if useMessages is false', () => {
       const client = new FinchClient({
         useMessages: false,

--- a/packages/client/src/client/FinchClient.ts
+++ b/packages/client/src/client/FinchClient.ts
@@ -22,7 +22,7 @@ interface FinchClientOptions {
   maxPortTimeoutCount?: number;
 }
 
-enum FinchClientStatus {
+export enum FinchClientStatus {
   Disconnected = 'disconnected',
   Connected = 'connected',
   Connecting = 'connecting',

--- a/packages/client/src/client/FinchClient.ts
+++ b/packages/client/src/client/FinchClient.ts
@@ -121,6 +121,17 @@ export class FinchClient {
     });
   }
 
+  /**
+   * queryApiViaPort will make a graphQL query to the background script via a [port](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/Port).
+   * This method has a timeout for messages build into it, because if a port is disconnected
+   * the would be no way to get a response without a timeout. There is also a max number of
+   * timeouts ( 10 by default ) that can trigger the port to attempt a reconnection.
+   *
+   * @param query A Document node or string to query the api
+   * @param variables Variables for this query
+   * @param options Any additional options for the query
+   * @returns The result of the query
+   */
   private queryApiViaPort<
     Query extends {} = {},
     Variables extends GenericVariables = {}


### PR DESCRIPTION
## Description

<!--
  Description: [REQUIRED]
  Please include a summary of the feature and the change which were created
  to ensure readers of this pull request know what they are looking at.
-->

Not sure exactly the scenario where this happens, but found out there is some instances where the extension port connection would essentially be orphaned from the background script connection. It seems like the onDisconnect event was not fired. I can only assume it had something to do with the background script shutting down, and the content script not being on an active tab.

This fix is a fail-safe to ensure the connection is not orphaned, or at least it has some other triggers to reconnect itself.

In this PR there is a fix for this issue.

- The extension can set the number of timed-out requests that it will allow before attempting to reconnect. This is probably different per team, so it's configurable and set pretty high.
- Once this condition is met the extension will attempt to reconnect, and cancel any pending queries that are still in the queue.

## Testing

<!--
  Testing: [Required]
  If you did not write any tests that are in your code please describe how
  you ensured this code does what the description says it does. You may be
  asked in the PR how you tested the feature if you do not fill this out.
-->

- [x] Includes test.
- [ ] Manually tested.

Finch Client was missing tests so you will see more tests than just the added functionality to at least test the surrounding functionality around this fix.

## Additional notes

<!--
  Additional notes: [Optional]
  Anything additional like if you had to refactor something, or if
  an additional dependency is being added and why.
-->

I am open to discussing if canceling or retrying the queries is the best way to handle this, I am a bit hesitant to do retries because it might cause mutation to potentially retry as well.
