### PR TITLE
Avoid calling port methods in case of no port

### DIFF
--- a/packages/client/src/client/FinchClient.test.ts
+++ b/packages/client/src/client/FinchClient.test.ts
@@ -26,6 +26,12 @@ describe('FinchClient', () => {
     afterEach(() => {
       browser.runtime.connect = originalConnect;
     });
+
+    it('should not throw when no port is connected', () => {
+      browser.runtime.connect = jest.fn().mockImplementation(() => undefined);
+      expect(() => new FinchClient()).not.toThrow();
+    });
+
     it('should attempt to connect a port if useMessages is false', () => {
       const client = new FinchClient({
         useMessages: false,

--- a/packages/client/src/client/FinchClient.ts
+++ b/packages/client/src/client/FinchClient.ts
@@ -92,7 +92,7 @@ export class FinchClient {
   }
 
   stop() {
-    this.port.disconnect();
+    this.port?.disconnect();
     // Timeout is to let the event fire before setting state
     setTimeout(() => {
       this.status = FinchClientStatus.Idle;
@@ -106,9 +106,11 @@ export class FinchClient {
       connectInfo: { name: this.portName },
     });
     this.port = port;
-    this.status = FinchClientStatus.Connected;
+    this.status = port
+      ? FinchClientStatus.Connected
+      : FinchClientStatus.Disconnected;
 
-    port.onDisconnect.addListener(() => {
+    port?.onDisconnect.addListener(() => {
       this.status = FinchClientStatus.Disconnected;
       this.portReconnectTimeout = window.setTimeout(() => {
         if (this.status === FinchClientStatus.Idle) {
@@ -185,7 +187,7 @@ export class FinchClient {
           Array.from(this.cancellableQueries.values()).forEach(cancelQuery =>
             cancelQuery(),
           );
-          this.port.disconnect();
+          this.port?.disconnect();
           this.connectPort();
         }
       }, options.timeout ?? this.messageTimeout);


### PR DESCRIPTION
## Description

<!--
  Description: [REQUIRED]
  Please include a summary of the feature and the change which were created
  to ensure readers of this pull request know what they are looking at.
-->

This PR fixes #313. The issues was that we were trying to use the port even if one was not created. This just makes sure we do not do this.

I wanted to add strict typing but ended up going down some type holes which was only able to fix with any. Going to take another stab at it later on, without the focus being taking on this bug.

## Testing

<!--
  Testing: [Required]
  If you did not write any tests that are in your code please describe how
  you ensured this code does what the description says it does. You may be
  asked in the PR how you tested the feature if you do not fill this out.
-->

- [ ] Includes test.
- [x] Manually tested.

Going to see if I can add a test for this.

## Additional notes

<!--
  Additional notes: [Optional]
  Anything additional like if you had to refactor something, or if
  an additional dependency is being added and why.
-->

_No additional information is given_
